### PR TITLE
use compressed style inputs

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/components/field_chooser/discover_field_search.tsx
+++ b/src/legacy/core_plugins/kibana/public/discover/components/field_chooser/discover_field_search.tsx
@@ -184,6 +184,7 @@ export function DiscoverFieldSearch({ onChange, value, types }: Props) {
           values: { id },
         })}
         data-test-subj={`${id}Select`}
+        compressed
       />
     );
   };
@@ -196,6 +197,7 @@ export function DiscoverFieldSearch({ onChange, value, types }: Props) {
           label={i18n.translate('kbn.discover.fieldChooser.filter.aggregatableLabel', {
             defaultMessage: 'Aggregatable',
           })}
+          display="columnCompressed"
         >
           {select('aggregatable', options, values.aggregatable)}
         </EuiFormRow>
@@ -204,6 +206,7 @@ export function DiscoverFieldSearch({ onChange, value, types }: Props) {
           label={i18n.translate('kbn.discover.fieldChooser.filter.searchableLabel', {
             defaultMessage: 'Searchable',
           })}
+          display="columnCompressed"
         >
           {select('searchable', options, values.searchable)}
         </EuiFormRow>
@@ -212,6 +215,7 @@ export function DiscoverFieldSearch({ onChange, value, types }: Props) {
           label={i18n.translate('kbn.discover.fieldChooser.filter.typeLabel', {
             defaultMessage: 'Type',
           })}
+          display="columnCompressed"
         >
           {select('type', typeOptions, values.type)}
         </EuiFormRow>


### PR DESCRIPTION
Updated form inputs to use the compressed style for PR https://github.com/elastic/kibana/pull/48452


<img width="373" alt="Screenshot 2019-10-29 10 47 03" src="https://user-images.githubusercontent.com/446285/67784557-f6ab1d80-fa39-11e9-93f7-11b2f9116e74.png">
