### PR TITLE
Design tweaks for Discover new data view

### DIFF
--- a/src/plugins/discover/public/application/main/components/sidebar/discover_index_pattern_management.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_index_pattern_management.tsx
@@ -60,7 +60,7 @@ export function DiscoverIndexPatternManagement(props: DiscoverIndexPatternManage
 
   return (
     <EuiPopover
-      panelPaddingSize="s"
+      panelPaddingSize="none"
       isOpen={isAddIndexPatternFieldPopoverOpen}
       closePopover={() => {
         setIsAddIndexPatternFieldPopoverOpen(false);
@@ -82,7 +82,8 @@ export function DiscoverIndexPatternManagement(props: DiscoverIndexPatternManage
       }
     >
       <EuiContextMenuPanel
-        size="s"
+        size="m"
+        title="Data view"
         items={[
           <EuiContextMenuItem
             key="add"
@@ -94,7 +95,7 @@ export function DiscoverIndexPatternManagement(props: DiscoverIndexPatternManage
             }}
           >
             {i18n.translate('discover.fieldChooser.indexPatterns.addFieldButton', {
-              defaultMessage: 'Add field to data view',
+              defaultMessage: 'Add field',
             })}
           </EuiContextMenuItem>,
           <EuiContextMenuItem
@@ -109,13 +110,13 @@ export function DiscoverIndexPatternManagement(props: DiscoverIndexPatternManage
             }}
           >
             {i18n.translate('discover.fieldChooser.indexPatterns.manageFieldButton', {
-              defaultMessage: 'Manage data view fields',
+              defaultMessage: 'Manage settings',
             })}
           </EuiContextMenuItem>,
           <EuiHorizontalRule style={{ margin: '0px' }} />,
           <EuiContextMenuItem
             key="new"
-            icon="indexSettings"
+            icon="plusInCircleFilled"
             data-test-subj="dataview-create-new"
             onClick={() => {
               setIsAddIndexPatternFieldPopoverOpen(false);


### PR DESCRIPTION
Thanks for adding this. After reviewing the UI changes, I would like to request a few changes. These also align with the forthcoming Unified Search efforts.

1. Add a title (to avoid redundant use of 'data view' text in each link)
2. Update link text/copy
3. Remove padding
4. Increase panel size from `s` to `m`

<img width="425" alt="Screen Shot 2022-01-26 at 12 18 00 PM" src="https://user-images.githubusercontent.com/446285/151223108-fd2836cc-5215-4fea-8418-200285d90a5f.png">

