### PR TITLE
Feedback for PR #125403

### DIFF
--- a/src/plugins/shared_ux/public/components/empty_state/assets/data_view_illustration.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/assets/data_view_illustration.tsx
@@ -17,6 +17,7 @@ export const DataViewIllustration = () => {
   const dataViewIllustrationVerticalStripes = css`
     fill: ${colors.fullShade};
   `;
+
   const dataViewIllustrationDots = css`
     fill: ${colors.lightShade};
   `;
@@ -549,6 +550,3 @@ export const DataViewIllustration = () => {
     </svg>
   );
 };
-
-/* eslint-disable import/no-default-export */
-export default DataViewIllustration;

--- a/src/plugins/shared_ux/public/components/empty_state/assets/index.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/assets/index.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+import { EuiLoadingSpinner } from '@elastic/eui';
+
+import { withSuspense } from '../../utility';
+
+export const LazyDataViewIllustration = React.lazy(() =>
+  import('../assets/data_view_illustration').then(({ DataViewIllustration }) => ({
+    default: DataViewIllustration,
+  }))
+);
+
+export const DataViewIllustration = withSuspense(
+  LazyDataViewIllustration,
+  <EuiLoadingSpinner size="xl" />
+);

--- a/src/plugins/shared_ux/public/components/empty_state/index.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/index.tsx
@@ -5,4 +5,5 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-export * from './no_data_views';
+
+export { NoDataViews } from './no_data_views';

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/__snapshots__/documentation_link.test.tsx.snap
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/__snapshots__/documentation_link.test.tsx.snap
@@ -1,177 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<DocumentationLink /> is rendered correctly 1`] = `
-<DocumentationLink
-  documentationUrl="dummy"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {
-        "date": Object {
-          "full": Object {
-            "day": "numeric",
-            "month": "long",
-            "weekday": "long",
-            "year": "numeric",
-          },
-          "long": Object {
-            "day": "numeric",
-            "month": "long",
-            "year": "numeric",
-          },
-          "medium": Object {
-            "day": "numeric",
-            "month": "short",
-            "year": "numeric",
-          },
-          "short": Object {
-            "day": "numeric",
-            "month": "numeric",
-            "year": "2-digit",
-          },
-        },
-        "number": Object {
-          "currency": Object {
-            "style": "currency",
-          },
-          "percent": Object {
-            "style": "percent",
-          },
-        },
-        "relative": Object {
-          "days": Object {
-            "units": "day",
-          },
-          "hours": Object {
-            "units": "hour",
-          },
-          "minutes": Object {
-            "units": "minute",
-          },
-          "months": Object {
-            "units": "month",
-          },
-          "seconds": Object {
-            "units": "second",
-          },
-          "years": Object {
-            "units": "year",
-          },
-        },
-        "time": Object {
-          "full": Object {
-            "hour": "numeric",
-            "minute": "numeric",
-            "second": "numeric",
-            "timeZoneName": "short",
-          },
-          "long": Object {
-            "hour": "numeric",
-            "minute": "numeric",
-            "second": "numeric",
-            "timeZoneName": "short",
-          },
-          "medium": Object {
-            "hour": "numeric",
-            "minute": "numeric",
-            "second": "numeric",
-          },
-          "short": Object {
-            "hour": "numeric",
-            "minute": "numeric",
-          },
-        },
-      },
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": Symbol(react.fragment),
-      "timeZone": null,
-    }
-  }
->
-  <dl>
-    <EuiTitle
-      size="xxs"
-    >
-      <dt
-        className="euiTitle euiTitle--xxsmall eui-displayInline"
-      >
-        <FormattedMessage
-          defaultMessage="Want to learn more?"
-          id="sharedUX.noDataViews.learnMore"
-          values={Object {}}
-        >
-          Want to learn more?
-        </FormattedMessage>
-      </dt>
-    </EuiTitle>
-     
-    <dd
+<dl>
+  <EuiTitle
+    size="xxs"
+  >
+    <dt
       className="eui-displayInline"
     >
-      <EuiLink
-        external={true}
-        href="dummy"
-        target="_blank"
-      >
-        <a
-          className="euiLink euiLink--primary"
-          href="dummy"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <FormattedMessage
-            defaultMessage="Read documentation"
-            id="sharedUX.noDataViews.readDocumentation"
-            values={Object {}}
-          >
-            Read documentation
-          </FormattedMessage>
-          <EuiIcon
-            aria-label="External link"
-            className="euiLink__externalIcon"
-            size="s"
-            type="popout"
-          >
-            <span
-              aria-label="External link"
-              className="euiLink__externalIcon"
-              data-euiicon-type="popout"
-              size="s"
-            />
-          </EuiIcon>
-          <EuiScreenReaderOnly>
-            <span
-              className="euiScreenReaderOnly"
-            >
-              <EuiI18n
-                default="(opens in a new tab or window)"
-                token="euiLink.newTarget.screenReaderOnlyText"
-              >
-                (opens in a new tab or window)
-              </EuiI18n>
-            </span>
-          </EuiScreenReaderOnly>
-        </a>
-      </EuiLink>
-    </dd>
-  </dl>
-</DocumentationLink>
+      <FormattedMessage
+        defaultMessage="Want to learn more?"
+        id="sharedUX.noDataViews.learnMore"
+        values={Object {}}
+      />
+    </dt>
+  </EuiTitle>
+   
+  <dd
+    className="eui-displayInline"
+  >
+    <EuiLink
+      external={true}
+      href="dummy"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Read documentation"
+        id="sharedUX.noDataViews.readDocumentation"
+        values={Object {}}
+      />
+    </EuiLink>
+  </dd>
+</dl>
 `;

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/documentation_link.test.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/documentation_link.test.tsx
@@ -6,14 +6,16 @@
  * Side Public License, v 1.
  */
 
-import { EuiLink, EuiTitle } from '@elastic/eui';
-import { DocumentationLink } from './documentation_link';
 import React from 'react';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
+
+import { EuiLink, EuiTitle } from '@elastic/eui';
+import { shallowWithIntl } from '@kbn/test-jest-helpers';
+
+import { DocumentationLink } from './documentation_link';
 
 describe('<DocumentationLink />', () => {
   test('is rendered correctly', () => {
-    const component = mountWithIntl(<DocumentationLink documentationUrl={'dummy'} />);
+    const component = shallowWithIntl(<DocumentationLink href={'dummy'} />);
     expect(component).toMatchSnapshot();
 
     expect(component.find('dl').length).toBe(1);

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/documentation_link.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/documentation_link.tsx
@@ -8,14 +8,13 @@
 
 import React from 'react';
 import { EuiLink, EuiTitle } from '@elastic/eui';
-
 import { FormattedMessage } from '@kbn/i18n-react';
 
 interface Props {
-  documentationUrl: string;
+  href: string;
 }
 
-export function DocumentationLink({ documentationUrl }: Props) {
+export function DocumentationLink({ href }: Props) {
   return (
     <dl>
       <EuiTitle size="xxs">
@@ -28,7 +27,7 @@ export function DocumentationLink({ documentationUrl }: Props) {
       </EuiTitle>
       &emsp;
       <dd className="eui-displayInline">
-        <EuiLink href={documentationUrl} target="_blank" external>
+        <EuiLink href={href} target="_blank" external>
           <FormattedMessage
             id="sharedUX.noDataViews.readDocumentation"
             defaultMessage="Read documentation"

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/index.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/index.tsx
@@ -6,8 +6,4 @@
  * Side Public License, v 1.
  */
 
-import { NoDataViewsPage } from './no_data_views_page';
-export { NoDataViewsPage } from './no_data_views_page';
-
-// eslint-disable-next-line import/no-default-export
-export default NoDataViewsPage;
+export { NoDataViews } from './no_data_views';

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.component.test.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.component.test.tsx
@@ -9,13 +9,13 @@
 import React from 'react';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { EuiButton, EuiPanel } from '@elastic/eui';
-import { NoDataViewsComponent } from './no_data_views_component';
+import { NoDataViews } from './no_data_views.component';
 import { DocumentationLink } from './documentation_link';
 
 describe('<NoDataViewsComponent />', () => {
   test('is rendered correctly', () => {
     const component = mountWithIntl(
-      <NoDataViewsComponent
+      <NoDataViews
         onClickCreate={jest.fn()}
         canCreateNewDataView={true}
         dataViewsDocLink={'dummy'}
@@ -27,14 +27,14 @@ describe('<NoDataViewsComponent />', () => {
   });
 
   test('does not render button if canCreateNewDataViews is false', () => {
-    const component = mountWithIntl(<NoDataViewsComponent canCreateNewDataView={false} />);
+    const component = mountWithIntl(<NoDataViews canCreateNewDataView={false} />);
 
     expect(component.find(EuiButton).length).toBe(0);
   });
 
   test('does not documentation link if linkToDocumentation is not provided', () => {
     const component = mountWithIntl(
-      <NoDataViewsComponent onClickCreate={jest.fn()} canCreateNewDataView={true} />
+      <NoDataViews onClickCreate={jest.fn()} canCreateNewDataView={true} />
     );
 
     expect(component.find(DocumentationLink).length).toBe(0);
@@ -43,7 +43,7 @@ describe('<NoDataViewsComponent />', () => {
   test('onClickCreate', () => {
     const onClickCreate = jest.fn();
     const component = mountWithIntl(
-      <NoDataViewsComponent canCreateNewDataView={true} onClickCreate={onClickCreate} />
+      <NoDataViews canCreateNewDataView={true} onClickCreate={onClickCreate} />
     );
 
     component.find('button').simulate('click');

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.component.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.component.tsx
@@ -6,16 +6,17 @@
  * Side Public License, v 1.
  */
 
-import React, { lazy, Suspense } from 'react';
+import React from 'react';
+import { css } from '@emotion/react';
+
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiButton, EuiEmptyPrompt, EuiLoadingSpinner, EuiEmptyPromptProps } from '@elastic/eui';
-import { css } from '@emotion/react';
+import { EuiButton, EuiEmptyPrompt, EuiEmptyPromptProps } from '@elastic/eui';
+
+import { DataViewIllustration } from '../assets';
 import { DocumentationLink } from './documentation_link';
 
-const Illustration = lazy(() => import('../assets/data_view_illustration'));
-
-interface Props {
+export interface Props {
   canCreateNewDataView: boolean;
   onClickCreate?: () => void;
   dataViewsDocLink?: string;
@@ -26,15 +27,15 @@ const createDataViewText = i18n.translate('sharedUX.noDataViewsPage.addDataViewT
   defaultMessage: 'Create Data View',
 });
 
-export const NoDataViewsComponent = ({
+// Using raw value because it is content dependent
+const MAX_WIDTH = 830;
+
+export const NoDataViews = ({
   onClickCreate,
   canCreateNewDataView,
   dataViewsDocLink,
   emptyPromptColor = 'plain',
 }: Props) => {
-  // Using raw value because it is content dependent
-  const maxWidth = '830px';
-
   const createNewButton = canCreateNewDataView && (
     <EuiButton
       onClick={onClickCreate}
@@ -51,14 +52,10 @@ export const NoDataViewsComponent = ({
       data-test-subj="noDataViewsPrompt"
       layout="horizontal"
       css={css`
-        max-width: ${maxWidth} !important;
+        max-width: ${MAX_WIDTH}px !important;
       `}
       color={emptyPromptColor}
-      icon={
-        <Suspense fallback={<EuiLoadingSpinner size="xl" />}>
-          <Illustration />
-        </Suspense>
-      }
+      icon={<DataViewIllustration />}
       title={
         <h2>
           <FormattedMessage
@@ -76,14 +73,15 @@ export const NoDataViewsComponent = ({
         <p>
           <FormattedMessage
             id="sharedUX.noDataViews.dataViewExplanation"
-            defaultMessage="Kibana requires a data view to identify which data streams, indices, and index aliases you want to explore. A
-      data view can point to a specific index, for example, your log data from
-      yesterday, or all indices that contain your log data."
+            defaultMessage="Kibana requires a data view to identify which data streams,
+            indices, and index aliases you want to explore. A data view can point to a
+            specific index, for example, your log data from yesterday, or all indices
+            that contain your log data."
           />
         </p>
       }
       actions={createNewButton}
-      footer={dataViewsDocLink && <DocumentationLink documentationUrl={dataViewsDocLink} />}
+      footer={dataViewsDocLink && <DocumentationLink href={dataViewsDocLink} />}
     />
   );
 };

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.mdx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.mdx
@@ -9,6 +9,6 @@
 
 When there is data in Elasticsearch, but there haven't been any data views created yet, we want to display an appropriate message to the user and facilitate creation of data views (if appropriate permissions are in place).
 
-The pure component, `no_data_views_component.tsx`, is a pre-configured **EuiEmptyPrompt**.
+The pure component, `no_data_views.component.tsx`, is a pre-configured **EuiEmptyPrompt**.
 
-The connected component, `no_data_views_page.tsx`, uses services from the `shared_ux` plugin to open Data View Editor. You must wrap your plugin app in the `ServicesContext` provided by the start contract of the `shared_ux` plugin to use it.
+The connected component, `no_data_views.tsx`, uses services from the `shared_ux` plugin to open Data View Editor. You must wrap your plugin app in the `ServicesContext` provided by the start contract of the `shared_ux` plugin to use it.

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.stories.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.stories.tsx
@@ -7,14 +7,17 @@
  */
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { NoDataViewsPage } from './no_data_views_page';
-import { NoDataViewsComponent } from './no_data_views_component';
-import mdx from './no_data_views_page.mdx';
+
 import { docLinksServiceFactory } from '../../../services/storybook/doc_links';
 
+import { NoDataViews as NoDataViewsComponent, Props } from './no_data_views.component';
+import { NoDataViews } from './no_data_views';
+
+import mdx from './no_data_views.mdx';
+
 export default {
-  title: 'No Data Views Page',
-  description: 'A page that displays when there are no user-created data views',
+  title: 'No Data Views',
+  description: 'A component to display when there are no user-created data views available.',
   parameters: {
     docs: {
       page: mdx,
@@ -24,31 +27,17 @@ export default {
 
 export const ConnectedComponent = () => {
   return (
-    <NoDataViewsPage
+    <NoDataViews
       onDataViewCreated={action('onDataViewCreated')}
       dataViewsDocLink={docLinksServiceFactory().dataViewsDocsLink}
     />
   );
 };
 
-ConnectedComponent.argTypes = {
-  openEditor: action('openEditor'),
-};
+type Params = Pick<Props, 'canCreateNewDataView' | 'dataViewsDocLink'>;
 
-export const PureComponent = ({
-  canCreateNewDataView = true,
-  dataViewDocLinks,
-}: {
-  canCreateNewDataView: boolean;
-  dataViewDocLinks: string | undefined;
-}) => {
-  return (
-    <NoDataViewsComponent
-      canCreateNewDataView={canCreateNewDataView}
-      onClickCreate={action('onClick')}
-      dataViewsDocLink={dataViewDocLinks}
-    />
-  );
+export const PureComponent = (params: Params) => {
+  return <NoDataViewsComponent onClickCreate={action('onClick')} {...params} />;
 };
 
 PureComponent.argTypes = {
@@ -56,7 +45,7 @@ PureComponent.argTypes = {
     control: 'boolean',
     defaultValue: true,
   },
-  dataViewDocLinks: {
+  dataViewsDocLink: {
     options: [docLinksServiceFactory().dataViewsDocsLink, undefined],
     control: { type: 'radio' },
   },

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.test.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.test.tsx
@@ -7,13 +7,14 @@
  */
 
 import React from 'react';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { ReactWrapper } from 'enzyme';
+
+import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { EuiButton } from '@elastic/eui';
 
 import { ServicesProvider, SharedUXServices } from '../../../services';
 import { servicesFactory } from '../../../services/mocks';
-import { NoDataViewsPage } from './no_data_views_page';
-import { EuiButton } from '@elastic/eui';
+import { NoDataViews } from './no_data_views';
 
 describe('<NoDataViewsPageTest />', () => {
   let services: SharedUXServices;
@@ -31,7 +32,7 @@ describe('<NoDataViewsPageTest />', () => {
 
   test('on dataView created', () => {
     const component = mount(
-      <NoDataViewsPage
+      <NoDataViews
         onDataViewCreated={jest.fn()}
         dataViewsDocLink={services.docLinks.dataViewsDocsLink}
       />

--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.tsx
@@ -7,17 +7,24 @@
  */
 
 import React, { useCallback, useEffect, useRef } from 'react';
-import { NoDataViewsComponent } from './no_data_views_component';
-import { useEditors, usePermissions } from '../../../services';
+
 import { DataView } from '../../../../../data_views/public';
+import { useEditors, usePermissions } from '../../../services';
+import type { SharedUXEditorsService } from '../../../services/editors';
+
+import { NoDataViews as NoDataViewsComponent } from './no_data_views.component';
 
 export interface Props {
   onDataViewCreated: (dataView: DataView) => void;
   dataViewsDocLink: string;
 }
 
-export const NoDataViewsPage = ({ onDataViewCreated, dataViewsDocLink }: Props) => {
-  const closeDataViewEditor = useRef<() => void | undefined>();
+type CloseDataViewEditorFn = ReturnType<SharedUXEditorsService['openDataViewEditor']>;
+
+export const NoDataViews = ({ onDataViewCreated, dataViewsDocLink }: Props) => {
+  const { canCreateNewDataView } = usePermissions();
+  const { openDataViewEditor } = useEditors();
+  const closeDataViewEditor = useRef<CloseDataViewEditorFn>();
 
   useEffect(() => {
     const cleanup = () => {
@@ -25,37 +32,32 @@ export const NoDataViewsPage = ({ onDataViewCreated, dataViewsDocLink }: Props) 
         closeDataViewEditor?.current();
       }
     };
+
     return () => {
       // Make sure to close the editor when unmounting
       cleanup();
     };
   }, []);
 
-  const setDataViewEditorRef = useCallback((ref: () => void | undefined) => {
+  const setDataViewEditorRef = useCallback((ref: CloseDataViewEditorFn) => {
     closeDataViewEditor.current = ref;
   }, []);
 
-  const { canCreateNewDataView } = usePermissions();
-  const { openDataViewEditor } = useEditors();
-  const createNewDataView = useCallback(() => {
+  const onClickCreate = useCallback(() => {
     if (!canCreateNewDataView) {
       return;
     }
+
     const ref = openDataViewEditor({
       onSave: (dataView) => {
         onDataViewCreated(dataView);
       },
     });
+
     if (setDataViewEditorRef) {
       setDataViewEditorRef(ref);
     }
   }, [canCreateNewDataView, openDataViewEditor, setDataViewEditorRef, onDataViewCreated]);
 
-  return (
-    <NoDataViewsComponent
-      onClickCreate={createNewDataView}
-      canCreateNewDataView={canCreateNewDataView}
-      dataViewsDocLink={dataViewsDocLink}
-    />
-  );
+  return <NoDataViewsComponent {...{ onClickCreate, canCreateNewDataView, dataViewsDocLink }} />;
 };


### PR DESCRIPTION
This is a collection of suggestions I had for #125403:

- Converting `lazy` imports to use `Promise`s.
- Consistent naming.
  - While we're using `Page`, this is only really a prompt.
  - Using singular/plural consistently.
- Typescript types for returns and refs
- Other nits and things.